### PR TITLE
Revert "ci: Pin pip to 20.2.2"

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,9 +29,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libkrb5-dev libxml2-dev libxmlsec1-dev libxmlsec1-openssl
-        # https://github.com/python-social-auth/social-app-django/issues/350
-        # https://github.com/pypa/pip/issues/10373
-        pip install -U pip==20.2.2 setuptools wheel
+        pip install -U pip setuptools wheel
         pip install -r devel.txt
 
     # only until a new upstream version with 3.8 support is released

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring
 
-# Copyright (c) 2020 Alexander Todorov <atodorov@MrSenko.com>
+# Copyright (c) 2020-2021 Alexander Todorov <atodorov@MrSenko.com>
 
 # Licensed under the GPL 3.0: https://www.gnu.org/licenses/gpl-3.0.txt
 
@@ -8,14 +8,14 @@ from setuptools import setup, find_packages
 
 
 def get_long_description():
-    with open('README.md', 'r') as file:
+    with open('README.md', 'r', encoding="utf-8") as file:
         return file.read()
 
 
 def get_install_requires(path):
     requires = []
 
-    with open(path, 'r') as file:
+    with open(path, 'r', encoding="utf-8") as file:
         for line in file:
             if line.startswith('-r '):
                 continue


### PR DESCRIPTION
This reverts commit fb902a1e831f72f718d5b3057836967f38d6dff3.

WARNING: Revert 44993e0b83ca4295347e81931bdd8b08ddf9b2b1 after
Kiwi TCMS v10.4 has been released upstream!