### PR TITLE
ci: Use version from setup.py and kiwitcms/version image as base

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,12 @@ jobs:
           git clone https://github.com/kiwitcms/Kiwi
           make -C Kiwi/ docker-image
 
-      - run: make docker-image
+      - run: |
+          echo "$QUAY_PUSH_TOKEN" | docker login -u="$QUAY_PUSH_USERNAME" --password-stdin quay.io
+
+          make docker-image
+
+          docker logout quay.io
 
   aarch64-tag-and-push-docker-image:
     machine:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,12 +35,13 @@ jobs:
         run: |
             VERSION=$(make echo-version)
 
+            echo "${{ secrets.QUAY_PUSH_TOKEN }}" | docker login -u="${{ secrets.QUAY_PUSH_USERNAME }}" --password-stdin quay.io
+
             make docker-image
             docker tag quay.io/kiwitcms/enterprise:$VERSION quay.io/kiwitcms/enterprise:$VERSION-$(uname -m)
 
             echo "+++++ Docker images +++++"
             docker images
 
-            echo "${{ secrets.QUAY_PUSH_TOKEN }}" | docker login -u="${{ secrets.QUAY_PUSH_USERNAME }}" --password-stdin quay.io
             docker push quay.io/kiwitcms/enterprise:$VERSION-$(uname -m)
             docker logout quay.io

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,9 +39,19 @@ jobs:
         git clone https://github.com/kiwitcms/Kiwi
         make -C Kiwi/ docker-image
 
+    - name: Login to Quay.io
+      if: matrix.command == 'docker-image'
+      run: |
+        echo "${{ secrets.QUAY_PUSH_TOKEN }}" | docker login -u="${{ secrets.QUAY_PUSH_USERNAME }}" --password-stdin quay.io
+
     - name: make ${{ matrix.command }}
       run: |
         make ${{ matrix.command }}
+
+    - name: Logout of Quay.io
+      if: matrix.command == 'docker-image'
+      run: |
+        docker logout quay.io
 
     - name: Setup - start and configure Keycloak server
       if: matrix.command == 'docker-image'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM kiwitcms/kiwi
+ARG KIWI_VERSION=latest
+FROM quay.io/kiwitcms/version:$KIWI_VERSION
 
 USER 0
 RUN microdnf --nodocs install krb5-libs xmlsec1 xmlsec1-openssl && \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-# *WARNING:* don't forget to update version in setup.py
-KIWI_VERSION=11.1
-ENTERPRISE_VERSION=$(KIWI_VERSION)-mt
+KIWI_VERSION=$(shell python3 setup.py --version)
+ENTERPRISE_VERSION=$(KIWI_VERSION)-mt-EXPERIMENT
 
 .PHONY: echo-version
 echo-version:
@@ -35,7 +34,7 @@ build-xmlsec:
 .PHONY: docker-image
 docker-image: build build-gssapi build-xmlsec
 	# everything else below is Enterprise + multi-tenant
-	docker build -t quay.io/kiwitcms/enterprise:$(ENTERPRISE_VERSION) .
+	docker build --build-arg KIWI_VERSION=$(KIWI_VERSION) -t quay.io/kiwitcms/enterprise:$(ENTERPRISE_VERSION) .
 	docker tag quay.io/kiwitcms/enterprise:$(ENTERPRISE_VERSION) quay.io/kiwitcms/enterprise:latest
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ def get_install_requires(path):
 
 setup(
     name='kiwitcms-enterprise',
-    # *WARNING:* don't forget to update version in Makefile
     version='11.1',
     description='Kiwi TCMS Enterprise Edition',
     long_description=get_long_description(),


### PR DESCRIPTION
- minimizes the places where version information needs to be
  stored/updated
- will pull the appropriate multi-arch base image based in build
  arguments (which are dependent on setup.py)