### PR TITLE
Use a pre-built container image for testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -56,12 +56,6 @@ jobs:
         cat /tmp/kc.env
         echo "**** END DEBUG ****"
 
-    - name: Setup - build OpenLDAP container from source
-      if: matrix.command == 'docker-image'
-      run: |
-        git clone https://github.com/kiwitcms/openldap.git
-        pushd openldap/ && git checkout openldap-2.4.41 && SKIP_SQUASH=1 make build && popd
-
     - name: Sanity test - boot the docker image
       if: matrix.command == 'docker-image'
       run: |

--- a/docker-compose.testing
+++ b/docker-compose.testing
@@ -3,7 +3,8 @@ version: '2'
 services:
     openldap_server:
         container_name: openldap_server
-        image: openshift/openldap-2441-centos7
+        # image: kiwitcms/openldap:2441-centos7-aarch64
+        image: kiwitcms/openldap:2441-centos7-x86_64
         restart: always
         ports:
             - 389:389


### PR DESCRIPTION
now that we figured out how to actually build it we're going to use a prebuilt container to save on some time in CI