### PR TITLE
Adjust search path for images during test

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -113,9 +113,11 @@ jobs:
         cat page.html | grep "or Continue With"
 
         # social backends are listed
-        for ICON in static.d/images/social_auth/backends/*.png; do
-            BACKEND=`basename $ICON | sed 's/.png//'`
-
+        # for ICON in tcms_enterprise/static/images/social_auth/backends/*.png; do
+        #    BACKEND=`basename $ICON | sed 's/.png//'`
+        # check only the backends enabled in test_settings.py b/c the directory above
+        # contains more images than backends which can be enabled during testing
+        for BACKEND in kerberos keycloak gitlab github github-app fedora; do
             cat page.html | grep "/login/$BACKEND/"
             cat page.html | grep "<img src='/static/images/social_auth/backends/$BACKEND.*.png'"
         done


### PR DESCRIPTION
the original directory has been renamed in
7bcfca1966b7844e77c5f4070d1f1802a27d261a and this should have been fixed back then