### PR TITLE
Install native Firefox and Geckodriver from Mozilla's DEB repository

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,14 +42,39 @@ jobs:
         pip install -U pip setuptools wheel
         pip install -r devel.txt
 
-        # used in test scripts
-        sudo apt-get install ldap-utils wrk
-        if [ -z `which firefox` ]; then
-            sudo apt-get install firefox
-        fi
-        if [ -z `which geckodriver` ]; then
-            sudo apt-get install firefox-geckodriver
-        fi
+    - name: Install packages used during container testing
+      if: matrix.command == 'test-docker-image'
+      run: |
+          # remove stock FF package
+          sudo snap remove firefox
+          sudo apt-get remove firefox
+
+          # used in test scripts
+          sudo apt-get install git make ldap-utils wrk
+
+          # install beakerlib from source it doesn't ship DEB packages
+          if [ ! -f "/usr/share/beakerlib/beakerlib.sh" ]; then
+              git clone https://github.com/beakerlib/beakerlib.git
+              sudo make -C beakerlib/ install
+          fi
+
+          # install Firefox and Geckodriver from Mozilla's DEB repository
+          # b/c Ubuntu 22.04 and later ships FF via snap package (a container)
+          # which causes issues with file access from RobotFramework tests
+          sudo apt-get install software-properties-common
+          sudo add-apt-repository --yes ppa:mozillateam/ppa
+
+          # prioritize the 3rd party repository
+          sudo tee /etc/apt/preferences.d/mozilla-firefox << EOF
+          Package: *
+          Pin: release o=LP-PPA-mozillateam
+          Pin-Priority: 1001
+
+          Package: firefox
+          Pin: version 1:1snap1-0ubuntu2
+          Pin-Priority: -1
+          EOF
+          sudo apt-get install firefox firefox-geckodriver
 
     - name: Login to Quay.io
       if: matrix.command == 'test-docker-image'

--- a/testing/runner.sh
+++ b/testing/runner.sh
@@ -6,16 +6,6 @@
 rm -rf /var/tmp/beakerlib-*/
 export BEAKERLIB_JOURNAL=0
 
-# install beakerlib from source b/c beakerlib doesn't ship
-# .deb packages
-if [ ! -f "/usr/share/beakerlib/beakerlib.sh" ]; then
-    sudo apt-get update
-    sudo apt-get install git make
-    git clone https://github.com/beakerlib/beakerlib.git
-    make -C beakerlib/ install
-fi
-
-
 # start and configure Keycloak server
 echo "**** STARTING KEYCLOAK ****"
 ./testing/start_keycloak.sh


### PR DESCRIPTION
snap packages in Ubuntu 22.04 and later are causing issues with filesystem access because a snap package is a container!

See:
https://github.com/mozilla/geckodriver/releases/tag/v0.34.0 and https://firefox-source-docs.mozilla.org/testing/geckodriver/Usage.html#running-firefox-in-a-container-based-package

> When Firefox is packaged inside a container (e.g. Snap, Flatpak),
> it may see a different filesystem to the host....

> This is known to affect launching the default Firefox shipped with Ubuntu 22.04+

Also move beakerlib setup inside GHA because this is where it belongs.