### PR TITLE
Adjust path to cookie file during testing

### DIFF
--- a/testing/test_docker.sh
+++ b/testing/test_docker.sh
@@ -278,10 +278,10 @@ rlJournalStart
         # login and create the cookies file
         get_dashboard "$HTTPS"
 
-        SESSION_ID=$(grep sessionid /tmp/login-cookies.txt | cut -f 7)
+        SESSION_ID=$(grep sessionid ./login-cookies.txt | cut -f 7)
         COMPLETED_REQUESTS=$(exec_wrk "$HTTPS/" "$WRK_DIR" "dashboard" "Cookie: sessionid=$SESSION_ID")
         rlLogInfo "COMPLETED_REQUESTS=$COMPLETED_REQUESTS in 10 seconds"
-        rlAssertGreaterOrEqual ">= 190 r/s" "$COMPLETED_REQUESTS" 1900
+        rlAssertGreaterOrEqual ">= 40 r/s" "$COMPLETED_REQUESTS" 400
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
the /tmp prefix was dropped in 6cc221f3 and instead of hitting the dashboard page this snippet has been measuring the number of redirects to the login page instead!