### PR TITLE
Include ethicalads.io domain in CSP header

### DIFF
--- a/etc/nginx.openresty
+++ b/etc/nginx.openresty
@@ -86,7 +86,7 @@ http {
     }
 
     # WARNING: make sure these match tcms.core.middleware.ExtraHeadersMiddleware
-    add_header Content-Security-Policy "script-src 'self' cdn.crowdin.com plausible.io;";
+    add_header Content-Security-Policy "script-src 'self' cdn.crowdin.com *.ethicalads.io plausible.io;";
 
     server {
         listen       8080;

--- a/testing/test_docker.sh
+++ b/testing/test_docker.sh
@@ -186,7 +186,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Should send Content-Security-Policy header"
-        rlRun -t -c "curl -k -D- $HTTPS 2>/dev/null | grep $'Content-Security-Policy: script-src \'self\' cdn.crowdin.com plausible.io;'"
+        rlRun -t -c "curl -k -D- $HTTPS 2>/dev/null | grep $'Content-Security-Policy: script-src \'self\' cdn.crowdin.com \*.ethicalads.io plausible.io;'"
     rlPhaseEnd
 
     rlPhaseStartTest "Should send uploads with exactly 1 'Content-Type: text/plain' header"


### PR DESCRIPTION
this is present in the upstream Kiwi TCMS configuration and eventhough it is not used here removing it causes troubles for other downstream builds which rely on this value.

For example our public.tenant.kiwitcms.org builds!