### PR TITLE
Disable -source and -debuginfo repositories for CentOS Stream 9

### DIFF
--- a/Dockerfile.xmlsec
+++ b/Dockerfile.xmlsec
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Alexander Todorov <atodorov@otb.bg>
+# Copyright (c) 2021-2025 Alexander Todorov <atodorov@otb.bg>
 #
 # Licensed under GNU Affero General Public License v3 or later (AGPLv3+)
 # https://www.gnu.org/licenses/agpl-3.0.html
@@ -8,9 +8,10 @@
 FROM quay.io/centos/centos:stream9
 
 RUN sed -i "s/enabled=0/enabled=1/" /etc/yum.repos.d/centos.repo && \
-    dnf -y install gcc python3.11-devel libtool-ltdl-devel pkgconf-pkg-config \
+    dnf -y --disablerepo="*-source" --disablerepo="*-debuginfo" install \
+        gcc python3.11-devel libtool-ltdl-devel pkgconf-pkg-config \
         libxml2-devel libxslt-devel xmlsec1-devel xmlsec1-openssl-devel opensc softhsm openssl-pkcs11 && \
-    dnf -y update
+    dnf -y --disablerepo="*-source" --disablerepo="*-debuginfo" update
 
 ENV PATH /venv/bin:${PATH} \
     VIRTUAL_ENV /venv


### PR DESCRIPTION
we don't install anything from these and mirrors are often broken leading to build errors such as:

Error: Failed to download metadata for repo 'baseos-source':
	Cannot download repomd.xml:
	Cannot download repodata/repomd.xml:
	All mirrors were tried