### PR TITLE
ci: Build intermediary Kiwi image from atodorov:update-django-dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ jobs:
     resource_class: arm.medium
     # Add steps to the job
     # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    environment:
+      RUNTIME_BASE: registry.access.redhat.com/ubi10-minimal:latest
     steps:
       - checkout
       - run: uname -a
@@ -25,6 +27,11 @@ jobs:
           pip3 install -r devel.txt \
             --index-url https://$PKG_TOKEN@pkg.kiwitcms.eu/pypi/ \
             --extra-index-url https://pypi.org/simple/
+
+      - run: |
+          git clone https://github.com/kiwitcms/Kiwi
+          make -C Kiwi/ docker-image
+          docker tag pub.kiwitcms.eu/kiwitcms/kiwi:latest hub.kiwitcms.eu/kiwitcms/version:15.4
 
       - run: |
           echo "$QUAY_PUSH_TOKEN" | docker login -u="$QUAY_PUSH_USERNAME" --password-stdin hub.kiwitcms.eu

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -109,6 +109,15 @@ jobs:
       run: |
         echo "${{ secrets.QUAY_PUSH_TOKEN }}" | docker login -u="${{ secrets.QUAY_PUSH_USERNAME }}" --password-stdin hub.kiwitcms.eu
 
+    - name: Build intermediary kiwitcms/kiwi image
+      if: matrix.command == 'test-docker-image'
+      env:
+        RUNTIME_BASE: registry.access.redhat.com/ubi10-minimal:latest
+      run: |
+          git clone https://github.com/kiwitcms/Kiwi
+          make -C Kiwi/ docker-image
+          docker tag pub.kiwitcms.eu/kiwitcms/kiwi:latest hub.kiwitcms.eu/kiwitcms/version:15.4
+
     - name: make ${{ matrix.command }}
       env:
         PKG_TOKEN: ${{ secrets.GEMFURY_PULL_TOKEN }}

--- a/docker-compose.testing
+++ b/docker-compose.testing
@@ -25,7 +25,7 @@ services:
 
     web:
         container_name: web
-        image: hub.kiwitcms.eu/kiwitcms/enterprise:latest
+        image: hub.kiwitcms.eu/kiwitcms/enterprise:15.4-mt-x86_64
         # IMPORTANT: ^^^ for Production deployments pin to a specific version number, see
         # https://kiwitcms.org/containers/
         depends_on:


### PR DESCRIPTION
This reapplies commit 9712775a4911994a67e3aae12bc70f5b060214c4 (originally reverting d197539956667ae68af1d8dab1f90156fe582b38) but configures CircleCI to checkout and build from the `atodorov/Kiwi` repository on branch `update-django-dependency`.

Note: GitHub Actions (.github/workflows/testing.yml) changes were excluded from this PR to avoid scope authorization requirements.