### PR TITLE
DEBUG: print sent emails logs during testing

### DIFF
--- a/testing/test_docker.sh
+++ b/testing/test_docker.sh
@@ -212,6 +212,7 @@ rlJournalStart
         # DEBUG
         rlRun "docker exec web ls -l /Kiwi/uploads/"
         rlRun "docker exec web ls -l /Kiwi/uploads/email-messages/"
+        rlRun "docker exec web find /Kiwi/uploads/email-messages/ -type f -exec cat {} \;"
         rlRun "docker exec web grep -hR passwordreset/confirm  /Kiwi/uploads/email-messages/"
     rlPhaseEnd
 


### PR DESCRIPTION
Short-circuiting the test suite execution via exit 0 inside testing/test_docker.sh right after running password-reset.robot to speed up debugging, with extra email output debug info.