### PR TITLE
Remove deprecated license specifier from setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[metadata]
+license = AGPLv3+
+license_files = LICENSE
+
 [flake8]
 max-line-length = 102
 extend-ignore = E203

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     author="Kiwi TCMS",
     author_email="kiwitcms@mrsenko.com",
     url="https://github.com/MrSenko/kiwitcms-enterprise/",
-    license="AGPLv3+",
     install_requires=get_install_requires("requirements.txt"),
     include_package_data=True,
     packages=find_packages(),
@@ -46,8 +45,6 @@ setup(
         "Topic :: Software Development :: Testing",
         "Environment :: Web Environment",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: "
-        "GNU Affero General Public License v3 or later (AGPLv3+)",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
     ],


### PR DESCRIPTION
This PR removes the deprecated `license` argument and classifier from `setup.py` and specifies `license_files` in `setup.cfg` instead, in accordance with https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license.

This prevents the `SetuptoolsDeprecationWarning: License classifiers are deprecated.` warning during builds.